### PR TITLE
Remove check for childRestObjs size in the assign method of RestObject

### DIFF
--- a/src/main/java/net/nuagenetworks/bambou/RestObject.java
+++ b/src/main/java/net/nuagenetworks/bambou/RestObject.java
@@ -334,11 +334,7 @@ public class RestObject implements RestObjectOperations, Serializable {
 
     @Override
     public void assign(RestSession<?> session, List<? extends RestObject> childRestObjs, boolean commit) throws RestException {
-        // Make sure there are child objects passed in
-        if (childRestObjs.isEmpty()) {
-            throw new RestException("No child objects specified");
-        }
-
+        
         // Extract IDs from the specified child objects
         List<String> ids = new ArrayList<String>();
         for (RestObject restObject : childRestObjs) {

--- a/src/main/java/net/nuagenetworks/bambou/RestObject.java
+++ b/src/main/java/net/nuagenetworks/bambou/RestObject.java
@@ -334,6 +334,11 @@ public class RestObject implements RestObjectOperations, Serializable {
 
     @Override
     public void assign(RestSession<?> session, List<? extends RestObject> childRestObjs, boolean commit) throws RestException {
+    	
+    	// Make sure the child objects passed in is not null     
+    	if (childRestObjs == null) {	
+    		throw new RestException("Child objects was null.");	
+    	}
         
         // Extract IDs from the specified child objects
         List<String> ids = new ArrayList<String>();


### PR DESCRIPTION
The check for childRestObjs size prevents a user from un-assigning all objects that are assigned to a given object. An example where this occurs is is with and PolicyGroup the VPorts that are assigned to it. Because of this check in RestObject, I cannot un-assign all VPorts from a PolicyGroup, thus I can't delete a PolicyGroup. Another example is PatNatPools assigned to a Vlan.
This code change has not been tested, as I am currently having issues cloning this repo.