### PR TITLE
Issue #10: RestClientService: Regional Special Characters Being Garbled

### DIFF
--- a/src/main/java/net/nuagenetworks/bambou/RestUtils.java
+++ b/src/main/java/net/nuagenetworks/bambou/RestUtils.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import net.nuagenetworks.bambou.util.BambouUtils;
 
 public class RestUtils {
-
+	private static final ObjectMapper mapper = new ObjectMapper();
     public static <T extends RestObject> T createRestObjectWithContent(Class<T> restObjectClass, JsonNode jsonNode) throws RestException {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
@@ -19,5 +19,19 @@ public class RestUtils {
 
     public static String toString(Object content) throws RestException {
         return BambouUtils.toString(content);
+    }
+    
+    public static JsonNode toJson(String content) throws RestException {
+    	try {
+			return mapper.readTree(content);
+		} catch (Exception e) {
+			try {
+				return mapper.valueToTree(content);
+			}
+			catch(IllegalArgumentException ex) {
+				throw new RestException(ex);
+			}
+			
+		}
     }
 }

--- a/src/main/java/net/nuagenetworks/bambou/service/RestClientService.java
+++ b/src/main/java/net/nuagenetworks/bambou/service/RestClientService.java
@@ -27,9 +27,9 @@
 package net.nuagenetworks.bambou.service;
 
 import java.io.IOException;
+import java.net.HttpRetryException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.net.HttpRetryException;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -46,18 +46,17 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.ResourceAccessException;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import net.nuagenetworks.bambou.RestException;
 import net.nuagenetworks.bambou.RestStatusCodeException;
+import net.nuagenetworks.bambou.RestUtils;
 import net.nuagenetworks.bambou.ssl.DynamicKeystoreGenerator;
 import net.nuagenetworks.bambou.ssl.NaiveHostnameVerifier;
 import net.nuagenetworks.bambou.ssl.X509NaiveTrustManager;
@@ -116,9 +115,9 @@ public class RestClientService {
     }
 
     private <T, U> ResponseEntity<T> sendRequest(HttpMethod method, String uri, HttpEntity<U> content, Class<T> responseType) throws RestException {
-        ResponseEntity<String> response = null;
+        ResponseEntity<JsonNode> response = null;
         try {
-            response = restOperations.exchange(uri, method, content, String.class);
+            response = restOperations.exchange(uri, method, content, JsonNode.class);
         } catch (ResourceAccessException e) {
             if (e.getCause() instanceof HttpRetryException) {
                 logger.info("Got HttpRetryException");
@@ -128,14 +127,14 @@ public class RestClientService {
             throw e;
         }
 
-        String responseBody = response.getBody();
+        JsonNode responseBody = response.getBody();
         HttpStatus statusCode = response.getStatusCode();
         ObjectMapper objectMapper = new ObjectMapper();
 
         try {
             HttpStatus.Series series = statusCode.series();
             if (series != HttpStatus.Series.CLIENT_ERROR && series != HttpStatus.Series.SERVER_ERROR) {
-                T body = (responseBody != null) ? objectMapper.readValue(responseBody, responseType) : null;
+                T body = (responseBody != null) ? objectMapper.readValue(RestUtils.toString(responseBody), responseType) : null;
                 return new ResponseEntity<T>(body, response.getHeaders(), response.getStatusCode());
             } else {
                 try {
@@ -145,8 +144,8 @@ public class RestClientService {
                     // Try to retrieve an error message from the response
                     // content (in JSON format)
                     String errorMessage = null;
-                    JsonNode responseObj = objectMapper.readTree(responseBody);
-                    ArrayNode errorsNode = (ArrayNode) responseObj.get("errors");
+                    
+                    ArrayNode errorsNode = (ArrayNode) responseBody.get("errors");
                     if (errorsNode != null && errorsNode.size() > 0) {
                         JsonNode error = errorsNode.get(0);
                         ArrayNode descriptionsNode = (ArrayNode) error.get("descriptions");
@@ -171,7 +170,7 @@ public class RestClientService {
                     // Try to retrieve an error code from the response
                     // content (in JSON format)
                     String internalErrorCode = null;
-                    JsonNode internalErrorCodeNode = responseObj.get("internalErrorCode");
+                    JsonNode internalErrorCodeNode = responseBody.get("internalErrorCode");
                     if (internalErrorCodeNode != null) {
                         internalErrorCode = internalErrorCodeNode.asText();
                     }
@@ -179,7 +178,9 @@ public class RestClientService {
                     // Raise an exception with status code, description and
                     // internal error code
                     throw new RestStatusCodeException(statusCode, errorMessage, internalErrorCode);
-                } catch (JsonParseException | JsonMappingException ex) {
+                } catch(RestStatusCodeException ex) {
+                	throw ex;
+                } catch (Exception ex) {
                     // No error message available in the response
                     switch (statusCode.series()) {
                     case CLIENT_ERROR:

--- a/src/test/java/net/nuagenetworks/bambou/RestClientServiceTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestClientServiceTest.java
@@ -41,6 +41,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.web.client.RestOperations;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import net.nuagenetworks.bambou.RestException;
 import net.nuagenetworks.bambou.service.RestClientService;
 import net.nuagenetworks.bambou.spring.TestSpringConfig;
@@ -63,8 +65,8 @@ public class RestClientServiceTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>(HttpStatus.OK));
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(HttpStatus.OK));
         EasyMock.replay(restOperations);
 
         ResponseEntity<String> response = restService.sendRequest(method, url, null, content, String.class);
@@ -83,8 +85,8 @@ public class RestClientServiceTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>("", HttpStatus.NOT_FOUND));
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(""), HttpStatus.NOT_FOUND));
         EasyMock.replay(restOperations);
 
         try {
@@ -93,7 +95,7 @@ public class RestClientServiceTest {
         } catch (RestStatusCodeException ex) {
             // Expect exception
             Assert.assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
-            Assert.assertEquals("404/Not Found", ex.getMessage());
+            Assert.assertEquals("404 Not Found", ex.getMessage());
             Assert.assertNull(ex.getInternalErrorCode());
         }
 
@@ -108,8 +110,8 @@ public class RestClientServiceTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>("{ \"internalErrorCode\": \"1001\" }", HttpStatus.NOT_FOUND));
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("{ \"internalErrorCode\": \"1001\" }"), HttpStatus.NOT_FOUND));
         EasyMock.replay(restOperations);
 
         try {
@@ -133,8 +135,8 @@ public class RestClientServiceTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>("{\"errors\": [ { \"descriptions\": [ { \"description\": \"Error message\" } ] } ] }",
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("{\"errors\": [ { \"descriptions\": [ { \"description\": \"Error message\" } ] } ] }"),
                         HttpStatus.NOT_FOUND));
         EasyMock.replay(restOperations);
 
@@ -159,9 +161,9 @@ public class RestClientServiceTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>(
-                        "{\"errors\": [ { \"property\": \"My Property\", \"descriptions\": [ { \"description\": \"Error message\" } ] } ] }",
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(
+                        RestUtils.toJson("{\"errors\": [ { \"property\": \"My Property\", \"descriptions\": [ { \"description\": \"Error message\" } ] } ] }"),
                         HttpStatus.NOT_FOUND));
         EasyMock.replay(restOperations);
 

--- a/src/test/java/net/nuagenetworks/bambou/RestFetcherTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestFetcherTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.web.client.RestOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.nuagenetworks.bambou.RestException;
@@ -523,18 +524,18 @@ public class RestFetcherTest {
         // Expected REST calls
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>("[{ \"APIKey\": \"1\" }]", HttpStatus.OK));
+                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("[{ \"APIKey\": \"1\" }]"), HttpStatus.OK));
         if (simulate401Response) {
             EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/" + urlSuffix), EasyMock.eq(method),
-                    EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>("", HttpStatus.UNAUTHORIZED));
+                    EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(""), HttpStatus.UNAUTHORIZED));
             EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class)))
-                    .andReturn(new ResponseEntity<String>("[{ \"APIKey\": \"2\" }]", HttpStatus.OK));
+                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class)))
+                    .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("[{ \"APIKey\": \"2\" }]"), HttpStatus.OK));
         }
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/" + urlSuffix), EasyMock.eq(method),
-                EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>(responseString, responseHeaders, responseStatus));
+                EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(responseString), responseHeaders, responseStatus));
         EasyMock.replay(restOperations);
 
         // Start REST session

--- a/src/test/java/net/nuagenetworks/bambou/RestObjectTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestObjectTest.java
@@ -48,6 +48,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.nuagenetworks.bambou.RestException;
@@ -418,17 +419,17 @@ public class RestObjectTest {
         // Expected REST calls
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>("[{ \"APIKey\": \"1\" }]", HttpStatus.OK));
+                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("[{ \"APIKey\": \"1\" }]"), HttpStatus.OK));
         if (simulate401Response) {
             EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/" + urlSuffix), EasyMock.eq(method),
-                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>("", HttpStatus.UNAUTHORIZED));
+                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(""), HttpStatus.UNAUTHORIZED));
             EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class)))
-                    .andReturn(new ResponseEntity<String>("[{ \"APIKey\": \"2\" }]", HttpStatus.OK));
+                    EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class)))
+                    .andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("[{ \"APIKey\": \"2\" }]"), HttpStatus.OK));
         }
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/" + urlSuffix), EasyMock.eq(method),
-                EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(responseString, responseStatus));
+                EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(responseString), responseStatus));
         EasyMock.replay(restOperations);
 
         // Start REST session

--- a/src/test/java/net/nuagenetworks/bambou/RestPushCenterTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestPushCenterTest.java
@@ -42,6 +42,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -82,12 +83,12 @@ public class RestPushCenterTest {
     }
 
     @Test
-    public void testStartPushCenter() throws InterruptedException {
+    public void testStartPushCenter() throws InterruptedException, RestException {
         String url = "http://vsd";
 
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>("{}", HttpStatus.OK)).atLeastOnce();
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("{}"), HttpStatus.OK)).atLeastOnce();
         EasyMock.replay(restOperations);
 
         RestPushCenterLongPoll pushCenter = new RestPushCenterLongPoll(session);
@@ -112,7 +113,7 @@ public class RestPushCenterTest {
 
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(mapper.writeValueAsString(events), HttpStatus.OK)).atLeastOnce();
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(mapper.valueToTree(events), HttpStatus.OK)).atLeastOnce();
         EasyMock.replay(restOperations);
 
         listenerInvocationCount = 0;
@@ -140,7 +141,7 @@ public class RestPushCenterTest {
     }
 
     @Test
-    public void testPushCenterWith400Response() throws InterruptedException, JsonProcessingException, IOException {
+    public void testPushCenterWith400Response() throws InterruptedException, JsonProcessingException, IOException, RestException {
         String url = "http://vsd";
 
         Events events = new Events();
@@ -150,13 +151,13 @@ public class RestPushCenterTest {
 
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(mapper.writeValueAsString(events), HttpStatus.OK));
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(mapper.valueToTree(events), HttpStatus.OK));
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events?uuid=1"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(mapper.writeValueAsString(events), HttpStatus.OK));
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(mapper.valueToTree(events), HttpStatus.OK));
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events?uuid=1"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>("", HttpStatus.BAD_REQUEST));
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(""), HttpStatus.BAD_REQUEST));
         EasyMock.expect(restOperations.exchange(EasyMock.eq(url + "/events"), EasyMock.eq(HttpMethod.GET), EasyMock.anyObject(HttpEntity.class),
-                EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(mapper.writeValueAsString(events), HttpStatus.OK));
+                EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(mapper.valueToTree(events), HttpStatus.OK));
         EasyMock.replay(restOperations);
 
         RestPushCenterLongPoll pushCenter = new RestPushCenterLongPoll(session);

--- a/src/test/java/net/nuagenetworks/bambou/RestRootObjectTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestRootObjectTest.java
@@ -46,6 +46,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.nuagenetworks.bambou.RestException;
@@ -138,9 +139,9 @@ public class RestRootObjectTest {
         // Expected REST calls
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>("[{}]", HttpStatus.OK));
+                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson("[{}]"), HttpStatus.OK));
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/" + urlSuffix), EasyMock.eq(method),
-                EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(responseString, responseStatus));
+                EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(responseString), responseStatus));
         EasyMock.replay(restOperations);
 
         // Start REST session

--- a/src/test/java/net/nuagenetworks/bambou/RestSessionTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestSessionTest.java
@@ -47,6 +47,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.nuagenetworks.bambou.spring.TestSpringConfig;
@@ -121,8 +122,8 @@ public class RestSessionTest {
 
         EasyMock.reset(restOperations);
         Capture<HttpEntity<?>> capturedHttpEntity = EasyMock.newCapture();
-        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(String.class)))
-                .andReturn(new ResponseEntity<String>(HttpStatus.OK));
+        EasyMock.expect(restOperations.exchange(EasyMock.eq(url), EasyMock.eq(method), EasyMock.capture(capturedHttpEntity), EasyMock.eq(JsonNode.class)))
+                .andReturn(new ResponseEntity<JsonNode>(HttpStatus.OK));
         EasyMock.replay(restOperations);
 
         ResponseEntity<String> response = session.sendRequestWithRetry(method, url, null, null, content, String.class);
@@ -158,7 +159,7 @@ public class RestSessionTest {
 
         EasyMock.reset(restOperations);
         EasyMock.expect(restOperations.exchange(EasyMock.eq(apiUrl + '/' + apiPrefix + "/v2_1/root"), EasyMock.eq(HttpMethod.GET),
-                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(String.class))).andReturn(new ResponseEntity<String>(responseContent, responseStatusCode));
+                EasyMock.anyObject(HttpEntity.class), EasyMock.eq(JsonNode.class))).andReturn(new ResponseEntity<JsonNode>(RestUtils.toJson(responseContent), responseStatusCode));
         EasyMock.replay(restOperations);
 
         session.setUsername(username);

--- a/src/test/java/net/nuagenetworks/bambou/RestUtilsTest.java
+++ b/src/test/java/net/nuagenetworks/bambou/RestUtilsTest.java
@@ -31,11 +31,14 @@ import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -44,7 +47,7 @@ import net.nuagenetworks.bambou.spring.TestSpringConfig;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestSpringConfig.class, loader = AnnotationConfigContextLoader.class)
 public class RestUtilsTest {
-
+	private static final Logger logger = LoggerFactory.getLogger(RestUtilsTest.class);
     @Test
     public void testCreateRestObjectWithContent() throws RestException, JsonProcessingException, IOException {
         JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
@@ -62,5 +65,43 @@ public class RestUtilsTest {
         Assert.assertEquals("34567", restObj.getCreationDate());
         Assert.assertEquals("123456", restObj.getLastUpdatedDate());
         Assert.assertEquals("MyOwner", restObj.getOwner());
+    }
+    
+    @Test
+    public void testToString() throws RestException {
+    	RestObject object = new RestObject();
+    	object.setId("123");
+    	object.setParentId("456");
+    	object.setParentType("MyParentType");
+    	object.setCreationDate("34567");
+    	object.setLastUpdatedDate("123456");
+    	object.setOwner("MyOwner");
+    	
+    	String content = RestUtils.toString(object);
+    	JsonNode node = RestUtils.toJson(content);
+    	
+    	Assert.assertEquals("123", node.get("ID").asText());
+        Assert.assertEquals("456", node.get("parentID").asText());
+        Assert.assertEquals("MyParentType", node.get("parentType").asText());
+        Assert.assertEquals("34567", node.get("creationDate").asText());
+        Assert.assertEquals("123456", node.get("lastUpdatedDate").asText());
+        Assert.assertEquals("MyOwner", node.get("owner").asText());
+    }
+    
+    @Test
+    public void testToJson() throws RestException {
+    	
+    	JsonNode object = RestUtils.toJson("{ \"firstName\": \"John\", \"lastName\": \"Smith\", \"age\": 42}");
+    	JsonNode text = RestUtils.toJson("Hello World!");
+    	JsonNode empty = RestUtils.toJson("");
+    	JsonNode space = RestUtils.toJson(" ");
+    	
+    	Assert.assertEquals("John", object.get("firstName").asText());
+    	Assert.assertEquals("Smith", object.get("lastName").asText());
+    	Assert.assertEquals(42, object.get("age").asInt());
+    	
+    	Assert.assertEquals("Hello World!", text.asText());
+    	Assert.assertEquals("", empty.asText());
+    	Assert.assertEquals(" ", space.asText());
     }
 }


### PR DESCRIPTION
Changes:
* added toJson method to the RestUtils class allowing string content to
be converted to a Json object.
* updated sendRequest method to unmarshall the HTTP response payload to
a Json object instead of a string.
* updated Unit testing classes specifically to have the EasyMock expect
a JsonNode class instead of a String class.
* added 2 unit tests on RestUtilsTest to verify the toString and toJson
methods in RestUtils.

Testing:
* executed JUnit tests and observed all of them pass.
* packaged local instance of Bambou library and used it to overwrite the
existing bambou library in my local maven repository.
* launched VNS portal server locally.
* pointed VNS protal client to local server and launched.
* Opened organization that had branches (NSG) with accents in the
address field.
* observed that the accents show up (un-mangled) in VNS portal client.
* checked other screens in the portal clients and observed proper
operation.