### PR TITLE
Providing a way to send responseChoice for assign and unAssignAll methods

### DIFF
--- a/src/main/java/net/nuagenetworks/bambou/RestSession.java
+++ b/src/main/java/net/nuagenetworks/bambou/RestSession.java
@@ -286,6 +286,10 @@ public class RestSession<R extends RestRootObject> implements RestSessionOperati
     public void assign(RestObject restObj, List<? extends RestObject> childRestObjs, boolean commit) throws RestException {
         restObj.assign(this, childRestObjs, commit);
     }
+    @Override
+    public void assign(RestObject restObj, List<? extends RestObject> childRestObjs,Integer responseChoice, boolean commit) throws RestException {
+        restObj.assign(this, childRestObjs, responseChoice, commit);
+    }
 
     @Override
     public <T extends RestObject> List<T> get(RestFetcher<T> fetcher) throws RestException {

--- a/src/main/java/net/nuagenetworks/bambou/operation/RestObjectOperations.java
+++ b/src/main/java/net/nuagenetworks/bambou/operation/RestObjectOperations.java
@@ -56,6 +56,8 @@ public interface RestObjectOperations {
 
     void assign(List<? extends RestObject> childRestObjs, boolean commit) throws RestException;
     
+    void assign(List<? extends RestObject> childRestObjs,Integer responseChoice, boolean commit) throws RestException;
+    
 
     void fetch(RestSession<?> session) throws RestException;
 
@@ -81,4 +83,8 @@ public interface RestObjectOperations {
     void assign(RestSession<?> session, List<? extends RestObject> childRestObjs, boolean commit) throws RestException;
     
     void unassignAll(RestSession<?> session, Class<? extends RestObject> objectType, boolean commit) throws RestException;
+    
+    void unassignAll(RestSession<?> session, Class<? extends RestObject> objectType, Integer responseChoice ,boolean commit) throws RestException;
+
+    void assign(RestSession<?> session, List<? extends RestObject> childRestObjs, Integer responseChoice, boolean commit) throws RestException;
 }

--- a/src/main/java/net/nuagenetworks/bambou/operation/RestSessionOperations.java
+++ b/src/main/java/net/nuagenetworks/bambou/operation/RestSessionOperations.java
@@ -79,4 +79,6 @@ public interface RestSessionOperations {
 
     <T extends RestObject> int count(RestFetcher<T> fetcher, String filter, String orderBy, String[] groupBy, Integer page, Integer pageSize,
             String queryParameters, boolean commit) throws RestException;
+
+    void assign(RestObject restObj, List<? extends RestObject> childRestObjs, Integer responseChoice, boolean commit) throws RestException;
 }


### PR DESCRIPTION
Changes: -

- Adding responseChoice param to assign and unAssignAll methods.

Testing:-

- Able to assign and unAssignAll object, even when response choice required.